### PR TITLE
fix(EsLint): :bug: Remove import-sort

### DIFF
--- a/src/eslint/config/rules/import-sort.ts
+++ b/src/eslint/config/rules/import-sort.ts
@@ -7,16 +7,6 @@ export default <Linter.Config>{
 		'@simple-import-sort': simpleImportSort,
 	},
 	rules: {
-		'sort-imports': [
-			'warn',
-			{
-				ignoreCase: false,
-				ignoreDeclarationSort: true,
-				ignoreMemberSort: false,
-				allowSeparatedGroups: false,
-			},
-		],
-
 		'@simple-import-sort/imports': [
 			'warn',
 			{


### PR DESCRIPTION
Удалён блок стандартных правил сортировки импортов